### PR TITLE
Make it a bit clearer when no allowance was found

### DIFF
--- a/src/Token.tsx
+++ b/src/Token.tsx
@@ -154,7 +154,7 @@ class Token extends Component<TokenProps, TokenState> {
     return (
       <li className="Token">
         {this.state.symbol}: {this.toFloat(this.state.balance)}
-        {this.state.allowances.length > 0 &&
+        {this.state.allowances.length > 0 ?
           <ul>
             {this.state.allowances.map((allowance, i) => {
               return (
@@ -174,7 +174,8 @@ class Token extends Component<TokenProps, TokenState> {
                 </li>
               )
             })}
-          </ul>
+          </ul> :
+          <ul><li>No outstanding allowances</li></ul>
         }
       </li>
     )

--- a/src/Token.tsx
+++ b/src/Token.tsx
@@ -175,7 +175,7 @@ class Token extends Component<TokenProps, TokenState> {
               )
             })}
           </ul> :
-          <ul><li>No outstanding allowances</li></ul>
+          <ul><li>No allowances found</li></ul>
         }
       </li>
     )


### PR DESCRIPTION
I tested the app using an account which had several balances and no allowances, but I actually thought it did have allowances. So I was left wondering why I wasn't seeing a revoke option anywhere. 

<img width="159" alt="Screenshot 2020-02-13 at 19 12 20" src="https://user-images.githubusercontent.com/625766/74470411-62ed4800-4e96-11ea-883f-ec235719a555.png">

This PR makes it a bit clearer when the reason for that is that there are no allowances.

<img width="247" alt="Screenshot 2020-02-13 at 19 26 05" src="https://user-images.githubusercontent.com/625766/74470590-c37c8500-4e96-11ea-8604-85c3d7b212f7.png">

I think there are better and prettier ways to do this so I fully encourage you to reject this PR in favour of an alternative solution! But since today I created my first PR ever, I thought I'd keep up the momentum and go for a second instead of just posting a feature request to twitter ;)