### PR TITLE
Reduce logo image sizes

### DIFF
--- a/components/Header/ConnectButton.tsx
+++ b/components/Header/ConnectButton.tsx
@@ -4,34 +4,37 @@ import { useEthereum } from "utils/hooks/useEthereum";
 import { getChainLogo, shortenAddress } from "../common/util";
 
 const ConnectButton: React.FC = () => {
-  const { account, ensName, connect, disconnect, chainId, chainName } = useEthereum();
+  const { account, ensName, connect, disconnect, chainId, chainName } =
+    useEthereum();
 
   const buttonAction = account ? disconnect : connect;
-  const buttonText = account ? 'Disconnect' : 'Connect Wallet';
+  const buttonText = account ? "Disconnect" : "Connect Wallet";
 
   return (
-    <InputGroup style={{ width: 'fit-content' }}>
+    <InputGroup style={{ width: "fit-content" }}>
       <InputGroup.Prepend>
-        <InputGroup.Text style={{ borderColor: 'black' }}>
+        <InputGroup.Text style={{ borderColor: "black" }}>
           <img
             src={getChainLogo(chainId)}
             title={chainName}
             alt={chainName}
             height="24"
-            style={{ borderRadius: '50%', minWidth: 16 }}
+            style={{ borderRadius: "50%", minWidth: 16 }}
           />
         </InputGroup.Text>
       </InputGroup.Prepend>
-        {account &&
-          <InputGroup.Text style={{ borderRadius: 0, borderColor: 'black' }}>
-            {ensName ?? shortenAddress(account)}
-          </InputGroup.Text>
-        }
+      {account && (
+        <InputGroup.Text style={{ borderRadius: 0, borderColor: "black" }}>
+          {ensName ?? shortenAddress(account)}
+        </InputGroup.Text>
+      )}
       <InputGroup.Append style={{ marginLeft: account ? -1 : 0 }}>
-        <Button variant="outline-primary" onClick={buttonAction}>{buttonText}</Button>
+        <Button variant="outline-primary" onClick={buttonAction}>
+          {buttonText}
+        </Button>
       </InputGroup.Append>
     </InputGroup>
-  )
-}
+  );
+};
 
-export default ConnectButton
+export default ConnectButton;

--- a/components/common/LogoLink.tsx
+++ b/components/common/LogoLink.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React from "react";
+import Image from "next/image";
 
 interface Props {
   src: string;
@@ -8,8 +9,16 @@ interface Props {
 
 const LogoLink = ({ src, alt, href }: Props) => (
   <a href={href}>
-    <img src={src} alt={alt} height="24" style={{ borderRadius: '50%' }} />
+    <Image
+      src={src}
+      alt={alt}
+      objectFit="contain"
+      height="24"
+      width="24"
+      quality="100"
+      style={{ borderRadius: "50%" }}
+    />
   </a>
 );
 
-export default LogoLink
+export default LogoLink;


### PR DESCRIPTION
The nextjs `Image` component does resizing on our behalf to ship the final rendered sizes over the wire. This will speed up all page visitors and improve SEO. Side note - please consider adding `prettier` via a hook like husky so that my diff is not so large

## Before

![image](https://user-images.githubusercontent.com/3408480/174860432-a5373605-b30b-4ab4-9546-f6bcc2cfe30d.png)

## After

![image](https://user-images.githubusercontent.com/3408480/174860473-72fd09e5-e40b-4c9c-b6f9-ea47f2b1421d.png)

